### PR TITLE
UserProfile Modify 기능 구현

### DIFF
--- a/src/main/java/com/sparta/newsfeed_qna/controller/UserController.java
+++ b/src/main/java/com/sparta/newsfeed_qna/controller/UserController.java
@@ -1,13 +1,14 @@
 package com.sparta.newsfeed_qna.controller;
 
 import com.sparta.newsfeed_qna.dto.MessageDto;
+import com.sparta.newsfeed_qna.dto.UserProfileModifyRequestDto;
+import com.sparta.newsfeed_qna.dto.UserProfileModifyResponseDto;
 import com.sparta.newsfeed_qna.dto.UserSignupRequestDto;
+import com.sparta.newsfeed_qna.security.UserDetailsImpl;
 import com.sparta.newsfeed_qna.service.UserService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping
@@ -22,5 +23,12 @@ public class UserController {
     public ResponseEntity<?> signupUser(@RequestBody UserSignupRequestDto userSignupRequestDTO) {
         userService.signupNewUserAccount(userSignupRequestDTO);
         return ResponseEntity.ok(new MessageDto("사용자가 성공적으로 등록되었습니다."));
+    }
+
+    @PatchMapping("/api/users/profile")
+    public ResponseEntity<?> editUserProfile(@RequestBody UserProfileModifyRequestDto userProfileModifyRequestDto,
+                                                        @AuthenticationPrincipal UserDetailsImpl userDetails){
+        userService.editUserProfile(userProfileModifyRequestDto, userDetails.getUser());
+        return ResponseEntity.ok(new MessageDto("사용자 프로필을 수정하였습니다."));
     }
 }

--- a/src/main/java/com/sparta/newsfeed_qna/dto/UserProfileModifyRequestDto.java
+++ b/src/main/java/com/sparta/newsfeed_qna/dto/UserProfileModifyRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.newsfeed_qna.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserProfileModifyRequestDto {
+    private String userNickName;
+    private String userOneLiner;
+    private String password;
+}

--- a/src/main/java/com/sparta/newsfeed_qna/dto/UserProfileModifyResponseDto.java
+++ b/src/main/java/com/sparta/newsfeed_qna/dto/UserProfileModifyResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.newsfeed_qna.dto;
+
+import com.sparta.newsfeed_qna.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserProfileModifyResponseDto {
+    private String userName;
+    private String userNickName;
+    private String userOneLiner;
+
+    public UserProfileModifyResponseDto(User user) {
+        this.userName = user.getUserName();
+        this.userNickName = user.getUserNickname();
+        this.userOneLiner = user.getOneLiner();
+    }
+}

--- a/src/main/java/com/sparta/newsfeed_qna/entity/User.java
+++ b/src/main/java/com/sparta/newsfeed_qna/entity/User.java
@@ -1,5 +1,6 @@
 package com.sparta.newsfeed_qna.entity;
 
+import com.sparta.newsfeed_qna.dto.UserProfileModifyRequestDto;
 import com.sparta.newsfeed_qna.dto.UserSignupRequestDto;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -26,16 +27,20 @@ public class User {
     @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
+    private String userNickname;
+    @Column(nullable = false)
+    private String oneLiner; // 한줄 소개
+
     public User(UserSignupRequestDto userSignupRequestDTO){
         this.userName = userSignupRequestDTO.getUserName();
         this.password = userSignupRequestDTO.getPassword();
         this.email = userSignupRequestDTO.getEmail();
     }
 
-//    public User(String username, String password, String email) {
-//        this.username = username;
-//        this.password = password;
-//        this.email = email;
-//    }
+    public void profileUpdate(UserProfileModifyRequestDto userProfileModifyRequestDto){
+        this.userNickname = userProfileModifyRequestDto.getUserNickName();
+        this.oneLiner = userProfileModifyRequestDto.getUserOneLiner();
+    }
 }
 

--- a/src/main/java/com/sparta/newsfeed_qna/service/UserService.java
+++ b/src/main/java/com/sparta/newsfeed_qna/service/UserService.java
@@ -1,5 +1,7 @@
 package com.sparta.newsfeed_qna.service;
 
+import com.sparta.newsfeed_qna.dto.UserProfileModifyRequestDto;
+import com.sparta.newsfeed_qna.dto.UserProfileModifyResponseDto;
 import com.sparta.newsfeed_qna.dto.UserSignupRequestDto;
 import com.sparta.newsfeed_qna.entity.User;
 import com.sparta.newsfeed_qna.repository.UserRepository;
@@ -24,5 +26,19 @@ public class UserService {
             throw new IllegalArgumentException("중복된 email 입니다.");
         }
         userRepository.save(user);
+    }
+
+    public UserProfileModifyResponseDto editUserProfile(UserProfileModifyRequestDto userProfileModifyRequestDto, User user) {
+        User findUser = userRepository.findById(user.getUserId()).orElseThrow(()->
+                new NullPointerException("존재하지 않는 사용자 입니다."));
+        boolean passwordValidation = passwordEncoder.matches(userProfileModifyRequestDto.getPassword(), findUser.getPassword());
+        if(passwordValidation == true){
+            findUser.profileUpdate(userProfileModifyRequestDto);
+            userRepository.save(findUser);
+        } else {
+            throw new IllegalArgumentException("사용자 본인만 프로필 정보를 수정할 수 있습니다. 비밀번호를 다시 확인해주세요.");
+        }
+
+        return new UserProfileModifyResponseDto(findUser);
     }
 }


### PR DESCRIPTION
- `User` Entity에 userNickName, oneLiner 필드 추가 (닉네임, 한 줄 소개)
- `UserService`에 userProfile 수정 메서드 구현
- 수정 시, requestDto의 `userPassword`와 userDetail의 password가 일치해야 프로필 수정 가능하도록 하였음